### PR TITLE
Lab 5 SONiC training.

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -56,7 +56,8 @@ orchagent_SOURCES = \
             sfloworch.cpp \
             chassisorch.cpp \
             debugcounterorch.cpp \
-            natorch.cpp
+            natorch.cpp \
+            txmonorch.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -36,6 +36,7 @@ BufferOrch *gBufferOrch;
 SwitchOrch *gSwitchOrch;
 Directory<Orch*> gDirectory;
 NatOrch *gNatOrch;
+TxMonOrch *gTxMonOrch;
 
 bool gIsNatSupported = false;
 
@@ -219,6 +220,11 @@ bool OrchDaemon::init()
 
     gNatOrch = new NatOrch(m_applDb, m_stateDb, nat_tables, gRouteOrch, gNeighOrch);
 
+    TableConnector stateDbTxErr(m_stateDb, /*"TX_ERR_STATE"*/STATE_TX_ERR_TABLE_NAME);
+    TableConnector applDbTxErr(m_applDb, /*"TX_ERR_APPL"*/APP_TX_ERR_TABLE_NAME);
+    TableConnector confDbTxErr(m_configDb, /*"TX_ERR_CFG"*/CFG_PORT_TX_ERR_TABLE_NAME);
+    gTxMonOrch = new TxMonOrch(applDbTxErr, confDbTxErr, stateDbTxErr);
+
     /*
      * The order of the orch list is important for state restore of warm start and
      * the queued processing in m_toSync map after gPortsOrch->allPortsReady() is set.
@@ -227,7 +233,22 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, qos_orch, wm_orch, policer_orch, sflow_orch, debug_counter_orch};
+    m_orchList = { gSwitchOrch,
+                   gCrmOrch,
+                   gPortsOrch,
+                   gBufferOrch,
+                   gIntfsOrch,
+                   gNeighOrch,
+                   gRouteOrch,
+                   copp_orch,
+                   tunnel_decap_orch,
+                   qos_orch,
+                   wm_orch,
+                   policer_orch,
+                   sflow_orch,
+                   debug_counter_orch,
+                   gTxMonOrch
+    };
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -31,6 +31,7 @@
 #include "debugcounterorch.h"
 #include "directory.h"
 #include "natorch.h"
+#include "txmonorch.h"
 
 using namespace swss;
 

--- a/orchagent/txmonorch.cpp
+++ b/orchagent/txmonorch.cpp
@@ -1,0 +1,313 @@
+#include <linux/if_ether.h>
+
+#include <unordered_map>
+#include <utility>
+#include <exception>
+#include <string>
+
+#include "txmonorch.h"
+#include "orch.h"
+#include "port.h"
+#include "logger.h"
+#include "sai_serialize.h"
+#include "converter.h"
+#include "portsorch.h"
+#include <vector>
+
+extern PortsOrch*       gPortsOrch;
+
+//using namespace std::rel_ops;
+
+string tx_status_name [] = {"ok", "error", "unknown"};
+
+TxMonOrch::TxMonOrch(TableConnector appDbConnector,
+                     TableConnector confDbConnector,
+                     TableConnector stateDbConnector) :
+    Orch(confDbConnector.first, confDbConnector.second),
+    m_TxErrorTable(appDbConnector.first, appDbConnector.second),
+    m_stateTxErrorTable(stateDbConnector.first, stateDbConnector.second),
+    m_countersDb(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0),
+    m_countersTable(&m_countersDb, COUNTERS_TABLE),
+    m_countersMapTable(&m_countersDb, COUNTERS_PORT_NAME_MAP),
+    m_pollTimer(new SelectableTimer(timespec { .tv_sec = 0, .tv_nsec = 0 })),
+    m_PortsTxErrStat(),
+    m_pollPeriod(0)
+{
+    auto executor = new ExecutableTimer(m_pollTimer, this, TXMONORCH_SEL_TIMER);
+    Orch::addExecutor(executor);
+
+    SWSS_LOG_NOTICE("TxMonOrch initialized with table %s %s %s\n",
+                    appDbConnector.second.c_str(),
+                    stateDbConnector.second.c_str(),
+                    confDbConnector.second.c_str());
+}
+
+void TxMonOrch::startTimer(uint32_t interval)
+{
+    SWSS_LOG_ENTER();
+
+    try
+    {
+        auto interv = timespec { .tv_sec = interval, .tv_nsec = 0 };
+
+        SWSS_LOG_INFO("startTimer,  find executor %p\n", m_pollTimer);
+        m_pollTimer->setInterval(interv);
+        //is it ok to stop without having it started?
+        m_pollTimer->stop();
+        m_pollTimer->start();
+        m_pollPeriod = interval;
+    }
+    catch (...)
+    {
+        SWSS_LOG_ERROR("Failed to startTimer which might be due to failed to get timer\n");
+    }
+}
+
+int TxMonOrch::handlePeriodUpdate(const vector<FieldValueTuple>& data)
+{
+    bool needStart = false;
+    uint32_t periodToSet = 0;
+
+    SWSS_LOG_ENTER();
+
+    for (auto i : data)
+    {
+        try {
+            if (fvField(i) == TXMONORCH_FIELD_CFG_PERIOD)
+            {
+                periodToSet = to_uint<uint32_t>(fvValue(i));
+
+                needStart |= (periodToSet != m_pollPeriod);
+                SWSS_LOG_INFO("TX_ERR handle cfg update period new %d\n", periodToSet);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown field type %s\n", fvField(i).c_str());
+                return -1;
+            }
+        }
+        catch (...) {
+            SWSS_LOG_ERROR("Failed to handle period update\n");
+        }
+    }
+
+    if (needStart)
+    {
+        startTimer(periodToSet);
+        SWSS_LOG_INFO("TX_ERR poll timer restarted with interval %d\n", periodToSet);
+    }
+
+    return 0;
+}
+
+int TxMonOrch::handleThresholdUpdate(const string &port, const vector<FieldValueTuple>& data, bool clear)
+{
+    SWSS_LOG_ENTER();
+
+    try {
+        if (clear)
+        {
+            //attention, for clear, no data is empty
+            //tesThreshold(m_PortsTxErrStat[port]) = 0;
+            m_PortsTxErrStat.erase(port);
+            m_TxErrorTable.del(port);
+            m_stateTxErrorTable.del(port);
+            //todo, remove data from state_db and appl_db??
+            SWSS_LOG_INFO("TX_ERR threshold cleared for port %s\n", port.c_str());
+        }
+        else
+        {
+            for (auto i : data)
+            {
+                if (TXMONORCH_FIELD_CFG_THRESHOLD == fvField(i))
+                {
+                    TxErrorStatistics &tes = m_PortsTxErrStat[port];
+                    if (tesPortId(tes) == 0/*invalid id??*/)
+                    {
+                        //the first time this port is configured
+                        Port saiport;
+                        //what if port doesn't stand for a valid port?
+                        //that is, getPort returns false?
+                        //what if the interface is removed with threshold configured?
+                        if (gPortsOrch->getPort(port, saiport))
+                        {
+                            tesPortId(tes) = saiport.m_port_id;
+                        }
+                        tesState(tes) = TXMONORCH_PORT_STATE_UNKNOWN;
+                    }
+                    tesThreshold(tes) = to_uint<uint64_t>(fvValue(i));
+                    SWSS_LOG_INFO("TX_ERR threshold reset to %ld for port %s\n",
+                                  tesThreshold(tes), port.c_str());
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Unknown field type %s when handle threshold for %s\n",
+                                   fvField(i).c_str(), port.c_str());
+                    return -1;
+                }
+            }
+        }
+    }
+    catch (...) {
+        SWSS_LOG_ERROR("Fail to startTimer handle periodic update\n");
+    }
+
+    return 0;
+}
+
+/*handle configuration update*/
+void TxMonOrch::doTask(Consumer& consumer)
+{
+    int rc = 0;
+
+    SWSS_LOG_ENTER();
+    SWSS_LOG_INFO("TxMonOrch doTask consumer\n");
+
+    if (!gPortsOrch->allPortsReady())
+    {
+        SWSS_LOG_INFO("Ports not ready\n");
+        return;
+    }
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+
+        string key = kfvKey(t);
+        string op = kfvOp(t);
+        vector<FieldValueTuple> fvs = kfvFieldsValues(t);
+
+        rc = -1;
+
+        SWSS_LOG_INFO("TX_ERR %s operation %s set %s del %s\n",
+                      key.c_str(),
+                      op.c_str(), SET_COMMAND, DEL_COMMAND);
+        if (key == TXMONORCH_KEY_CFG_PERIOD)
+        {
+            if (op == SET_COMMAND)
+            {
+                rc = handlePeriodUpdate(fvs);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown operation type %s when set period\n", op.c_str());
+            }
+        }
+        else //key should be the alias of interface
+        {
+            if (op == SET_COMMAND)
+            {
+                //fetch the value which reprsents threshold
+                rc = handleThresholdUpdate(key, fvs, false);
+            }
+            else if (op == DEL_COMMAND)
+            {
+                //reset to default
+                rc = handleThresholdUpdate(key, fvs, true);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown operation type %s when set threshold\n", op.c_str());
+            }
+        }
+
+        if (rc)
+        {
+            SWSS_LOG_ERROR("Handle configuration update failed index %s\n", key.c_str());
+        }
+
+        consumer.m_toSync.erase(it++);
+    }
+}
+
+int TxMonOrch::pollOnePortErrorStatistics(const string &port, TxErrorStatistics &stat)
+{
+    uint64_t txErrStatistics = 0,
+        txErrStatLasttime = tesStatistics(stat),
+        txErrStatThreshold = tesThreshold(stat);
+    int tx_error_state,
+        tx_error_state_lasttime = tesState(stat);
+
+    SWSS_LOG_ENTER();
+
+    {
+        vector<FieldValueTuple> fvs;
+        std::stringstream stream;
+        stream << "oid:0x" << std::hex << tesPortId(stat);
+        std::string keystr( stream.str() );
+        m_countersTable.get(keystr, fvs);
+        for (auto fv: fvs)
+        {
+            if (fvField(fv) == "SAI_PORT_STAT_IF_OUT_ERRORS") {
+                txErrStatistics = stoll(fvValue(fv));
+                break;
+            }
+        }
+
+        SWSS_LOG_INFO("TX_ERR_POLL: got port %s tx_err stati %ld, lasttime %ld threshold %ld\n",
+                      port.c_str(), txErrStatistics, txErrStatLasttime, txErrStatThreshold);
+    }
+
+    if (txErrStatistics - txErrStatLasttime > txErrStatThreshold)
+    {
+        tx_error_state = TXMONORCH_PORT_STATE_ERROR;
+    }
+    else
+    {
+        tx_error_state = TXMONORCH_PORT_STATE_OK;
+    }
+    if (tx_error_state != tx_error_state_lasttime)
+    {
+        tesState(stat) = tx_error_state;
+        //set status in STATE_DB
+        vector<FieldValueTuple> fvs;
+        if (tx_error_state < TXMONORCH_PORT_STATE_MAX)
+            fvs.emplace_back(TXMONORCH_FIELD_STATE_TX_STATE, tx_status_name[tx_error_state]);
+        else
+            fvs.emplace_back(TXMONORCH_FIELD_STATE_TX_STATE, "invalid");
+        m_stateTxErrorTable.set(port, fvs);
+        SWSS_LOG_INFO("TX_ERR_CFG: port %s state changed to %d, push to db\n", port.c_str(), tx_error_state);
+    }
+
+    //refresh the local copy of last time statistics
+    tesStatistics(stat) = txErrStatistics;
+
+    return 0;
+}
+
+void TxMonOrch::pollErrorStatistics()
+{
+    SWSS_LOG_ENTER();
+
+    KeyOpFieldsValuesTuple portEntry;
+
+    for (auto& i : m_PortsTxErrStat)
+    {
+        vector<FieldValueTuple> fields;
+        int rc;
+
+        SWSS_LOG_INFO("TX_ERR_APPL: port %s tx_err_stat %ld, before get\n", i.first.c_str(),
+                        tesStatistics(i.second));
+        rc = pollOnePortErrorStatistics(i.first, i.second);
+        if (rc != 0)
+            SWSS_LOG_ERROR("TX_ERR_APPL: got port %s tx_err_stat failed %d\n", i.first.c_str(), rc);
+        fields.emplace_back(TXMONORCH_FIELD_APPL_STATI, to_string(tesStatistics(i.second)));
+        fields.emplace_back(TXMONORCH_FIELD_APPL_TIMESTAMP, "0");
+        fields.emplace_back(TXMONORCH_FIELD_APPL_SAIPORTID, to_string(tesPortId(i.second)));
+        m_TxErrorTable.set(i.first, fields);
+        SWSS_LOG_INFO("TX_ERR_APPL: port %s tx_err_stat %ld, push to db\n", i.first.c_str(),
+                        tesStatistics(i.second));
+    }
+
+    m_TxErrorTable.flush();
+    m_stateTxErrorTable.flush();
+    SWSS_LOG_INFO("TX_ERR_APPL: flushing tables\n");
+}
+
+void TxMonOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_INFO("TxMonOrch doTask selectable timer\n");
+    //for each ports, check the statisticis
+    pollErrorStatistics();
+}

--- a/orchagent/txmonorch.h
+++ b/orchagent/txmonorch.h
@@ -1,0 +1,88 @@
+#ifndef SWSS_TXMONORCH_H
+#define SWSS_TXMONORCH_H
+
+#include "orch.h"
+#include "producerstatetable.h"
+#include "observer.h"
+#include "portsorch.h"
+#include "selectabletimer.h"
+#include "table.h"
+#include "select.h"
+#include "timer.h"
+
+#include <map>
+#include <algorithm>
+#include <tuple>
+#include <inttypes.h>
+
+extern "C" {
+#include "sai.h"
+}
+
+/*fields definition*/
+#define TXMONORCH_FIELD_CFG_PERIOD      "tx_error_check_period"
+#define TXMONORCH_FIELD_CFG_THRESHOLD       "tx_error_threshold"
+
+#define TXMONORCH_FIELD_APPL_STATI      "tx_error_stati"
+#define TXMONORCH_FIELD_APPL_TIMESTAMP  "tx_error_timestamp"
+#define TXMONORCH_FIELD_APPL_SAIPORTID  "tx_error_portid"
+
+#define TXMONORCH_FIELD_STATE_TX_STATE  "tx_status"
+
+#define TXMONORCH_KEY_CFG_PERIOD    "GLOBAL_PERIOD"
+
+/*table names are defined in schema.h*/
+
+#define TXMONORCH_ERR_STATE     "tx_status"
+
+#define TXMONORCH_SEL_TIMER     "TX_ERR_COUNTERS_POLL"
+
+/*tx state definition*/
+#define TXMONORCH_PORT_STATE_OK         0
+#define TXMONORCH_PORT_STATE_ERROR      1
+#define TXMONORCH_PORT_STATE_UNKNOWN    2
+#define TXMONORCH_PORT_STATE_MAX        3
+
+typedef std::tuple<int, sai_object_id_t, uint64_t, uint64_t> TxErrorStatistics;//state, stati, threshold
+typedef std::map<std::string, TxErrorStatistics> TxErrorStatMap;
+
+#define tesState std::get<0>
+#define tesPortId std::get<1>
+#define tesStatistics std::get<2>
+#define tesThreshold std::get<3>
+
+class TxMonOrch : public Orch
+{
+public:
+    TxMonOrch(TableConnector appDbConnector,
+              TableConnector confDbConnector,
+              TableConnector stateDbConnector);
+
+private:
+    //representing PORT_TX_STATISTICS_TABLE in APPL_DB
+    Table m_TxErrorTable;
+    //representing PORT_TX_STAT_TABLE in STATE_DB
+    Table m_stateTxErrorTable;
+
+    //for fetching statistics
+    DBConnector m_countersDb;
+    Table m_countersTable;
+    Table m_countersMapTable;
+
+    TxErrorStatMap m_PortsTxErrStat;
+
+    /*should be accessed via an atomic approach?*/
+    uint32_t m_pollPeriod;
+    int m_poolPeriodChanged;
+    SelectableTimer *m_pollTimer;
+
+    void doTask(Consumer& consumer);
+    void doTask(SelectableTimer &timer);
+
+    void startTimer(uint32_t interval);
+    int handlePeriodUpdate(const vector<FieldValueTuple>& data);
+    int handleThresholdUpdate(const string &key, const vector<FieldValueTuple>& data, bool clear);
+    int pollOnePortErrorStatistics(const string &port, TxErrorStatistics &stat);
+    void pollErrorStatistics();
+};
+#endif /* SWSS_TXMONORCH_H */


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

What I did

Implemented a solution for Lab 5 in SONiC training based on one of the solutions provided in the Wiki, with some changes. These include using the counters DB instead of calls to SAI to retrieve the tx error counter, passing the statistics data by reference so that the difference between successive counter readings would be used correctly, and added python code to handle some not found conditions.

Why I did it

I used a prepared solution, studied it with gdb and modified it based on what I observed in gdb, because so much of the way code is written in C++ is unfamiliar that I expected writing from scratch would take an order of magnitude more than the time allotted, and I would get more benefit from studying and modifying existing code.

How I verified it

Configure polling period, e.g.

sudo config tx_error_stat_poll_period 30

Configure error threshold, e.g.

sudo config interface tx_error_threshold set Ethernet0 10

Disable automatic refresh of counters, so that counter values can be injected into DB and stay there:

counterpoll port disable

Lookup OID of port being tested, e.g.

redis-cli -n 2 hgetall "COUNTERS_PORT_NAME_MAP" | grep -A1 "Ethernet0"
Ethernet0
oid:0x10000000008d4

Inject tx errors to that port and verify that DB was updated:

redis-cli -n 2 hset "COUNTERS:oid:0x10000000008d4" "SAI_PORT_STAT_IF_OUT_ERRORS" "20"
(integer) 0
redis-cli -n 2 hget "COUNTERS:oid:0x10000000008d4" "SAI_PORT_STAT_IF_OUT_ERRORS"
"20"

Show status within the poll period:

show interfaces tx_error
Port status statistics

Ethernet0 error 20

Show status after the poll period:

show interfaces tx_error
Port status statistics

Ethernet0 ok 20

Repeat sequences of the above commands to verify that status becomes error when the delta exceeds the threshold, and ok when it doesn't.

Details if related