### PR TITLE
Orchagent validates mirror session queue parameter against maximum va…

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -38,7 +38,10 @@
 #define MIRROR_SESSION_DSCP_SHIFT       2
 #define MIRROR_SESSION_DSCP_MIN         0
 #define MIRROR_SESSION_DSCP_MAX         63
-#define MIRROR_SESSION_DEFAULT_NUM_TC   15
+
+// 15 is a typical value, but if vendor's SAI does not supply the maximum value,
+// allow all 8-bit numbers, effectively cancelling validation by orchagent.
+#define MIRROR_SESSION_DEFAULT_NUM_TC   255
 
 extern sai_switch_api_t *sai_switch_api;
 extern sai_mirror_api_t *sai_mirror_api;

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -38,7 +38,9 @@
 #define MIRROR_SESSION_DSCP_SHIFT       2
 #define MIRROR_SESSION_DSCP_MIN         0
 #define MIRROR_SESSION_DSCP_MAX         63
+#define MIRROR_SESSION_DEFAULT_NUM_TC   15
 
+extern sai_switch_api_t *sai_switch_api;
 extern sai_mirror_api_t *sai_mirror_api;
 extern sai_port_api_t *sai_port_api;
 
@@ -80,9 +82,26 @@ MirrorOrch::MirrorOrch(TableConnector stateDbConnector, TableConnector confDbCon
         m_policerOrch(policerOrch),
         m_mirrorTable(stateDbConnector.first, stateDbConnector.second)
 {
+    sai_status_t status;
+    sai_attribute_t attr;
+
     m_portsOrch->attach(this);
     m_neighOrch->attach(this);
     m_fdbOrch->attach(this);
+
+    // Retrieve the number of valid values for queue, starting at 0
+    attr.id = SAI_SWITCH_ATTR_QOS_MAX_NUMBER_OF_TRAFFIC_CLASSES;
+    status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Failed to get switch attribute number of traffic classes. \
+                       Use default value. rv:%d", status);
+        m_maxNumTC = MIRROR_SESSION_DEFAULT_NUM_TC;
+    }
+    else
+    {
+        m_maxNumTC = attr.value.u8;
+    }
 }
 
 bool MirrorOrch::bake()
@@ -373,6 +392,11 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
             else if (fvField(i) == MIRROR_SESSION_QUEUE)
             {
                 entry.queue = to_uint<uint8_t>(fvValue(i));
+                if (entry.queue >= m_maxNumTC)
+                {
+                    SWSS_LOG_ERROR("Failed to get valid queue %s", fvValue(i).c_str());
+                    return task_process_status::task_invalid_entry;
+                }
             }
             else if (fvField(i) == MIRROR_SESSION_POLICER)
             {

--- a/orchagent/mirrororch.h
+++ b/orchagent/mirrororch.h
@@ -95,6 +95,8 @@ private:
     NeighOrch *m_neighOrch;
     FdbOrch *m_fdbOrch;
     PolicerOrch *m_policerOrch;
+    // Maximum number of traffic classes starting at 0, thus queue can be 0 - m_maxNumTC-1
+    uint8_t m_maxNumTC;
 
     Table m_mirrorTable;
 

--- a/tests/test_mirror_port_span.py
+++ b/tests/test_mirror_port_span.py
@@ -7,6 +7,54 @@ import pytest
 @pytest.mark.usefixtures('dvs_mirror_manager')
 @pytest.mark.usefixtures('dvs_policer_manager')
 class TestMirror(object):
+
+    def check_syslog(self, dvs, marker, log, expected_cnt):
+        (ec, out) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep \'%s\' | wc -l" % (marker, log)])
+        assert out.strip() == str(expected_cnt)
+
+    
+    def test_PortMirrorQueue(self, dvs, testlog):
+        """
+        This test covers valid and invalid values of the queue parameter.  All sessions have source & dest port.
+        Operation flow:
+        1. Create mirror session with queue 0, verify session becomes active and error not written to log.
+        2. Create mirror session with queue max valid value, verify session becomes active and error not written to log.
+        3. Create mirror session with queue max valid value + 1, verify session doesnt get created and error written to log.
+        Due to lag in table operations, verify_no_mirror is necessary at the end of each step, to ensure cleanup before next step.
+        """
+
+        session = "TEST_SESSION"
+        dst_port = "Ethernet16"
+        src_ports = "Ethernet12"
+                
+        # Simulate SAI max number of traffic classes
+        dvs.setReadOnlyAttr('SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_QOS_MAX_NUMBER_OF_TRAFFIC_CLASSES', '15')
+        
+        # Sub Test 1
+        marker = dvs.add_log_marker()
+        self.dvs_mirror.create_span_session(session, dst_port, src_ports, direction="BOTH", queue="0")
+        self.dvs_mirror.verify_session_status(session)
+        self.dvs_mirror.remove_mirror_session(session)
+        self.dvs_mirror.verify_no_mirror()
+        self.check_syslog(dvs, marker, "Failed to get valid queue 0", 0)
+
+        # Sub Test 2
+        marker = dvs.add_log_marker()
+        self.dvs_mirror.create_span_session(session, dst_port, src_ports, direction="RX", queue="14")
+        self.dvs_mirror.verify_session_status(session)
+        self.dvs_mirror.remove_mirror_session(session)
+        self.dvs_mirror.verify_no_mirror()
+        self.check_syslog(dvs, marker, "Failed to get valid queue 14", 0)
+
+        # Sub Test 3
+        marker = dvs.add_log_marker()
+        self.dvs_mirror.create_span_session(session, dst_port, src_ports, direction="TX", queue="15")
+        self.dvs_mirror.verify_session_status(session, expected=0)
+        self.dvs_mirror.remove_mirror_session(session)
+        self.dvs_mirror.verify_no_mirror()
+        self.check_syslog(dvs, marker, "Failed to get valid queue 15", 1)
+        
+
     def test_PortMirrorAddRemove(self, dvs, testlog):
         """
         This test covers the basic SPAN mirror session creation and removal operations
@@ -469,7 +517,6 @@ class TestMirror(object):
         self.dvs_lag.remove_port_channel("008")
         self.dvs_lag.get_and_verify_port_channel(0)
         self.dvs_vlan.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_LAG", 0)
-
 
 
 # Add Dummy always-pass test at end as workaroud


### PR DESCRIPTION
…lue from SAI

Signed-off-by: Raphael Tryster <raphaelt@nvidia.com>

**What I did**

Orchagent queries SAI for the maximum value of the queue parameter.  If the value requested by the user is invalid, it writes an error in the log and does not pass the request to SAI/SDK.

**Why I did it**

Fixes https://github.com/Azure/sonic-buildimage/issues/8189[mirroring] Missing per-vendor validation of mirror session queue parameter.  Without this change, orchagent passes the invalid data to SAI/SDK which returns failure, causing orchagent to exit, effectively a system crash.

**How I verified it**

Manual and unit test: Create 3 mirror sessions with queue = 0, maximum valid value, lowest invalid value.  First two cases, sessions are created.  For last case, session not created in state DB and error in log.

**Details if related**
